### PR TITLE
Fix dialog centering reference

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -1042,8 +1042,8 @@ class GroupDialog(simpledialog.Dialog):
     def show(self):
         if not self._centered:
             self._centered = True
-            self.dialog.update_idletasks()
-            center_window(self.dialog, 400, 250)
+            self.update_idletasks()
+            center_window(self, 400, 250)
 
 # --- Send Emails Dialog ---
 def send_emails_dialog(tree):


### PR DESCRIPTION
## Summary
- use `self` instead of `self.dialog` when centering in `GroupDialog.show`

## Testing
- `python -m py_compile ui.py contact_dialog.py`


------
https://chatgpt.com/codex/tasks/task_e_6840268f2be083239148bee35bb5be01