### PR TITLE
Fix import path

### DIFF
--- a/features/contacts_ui.py
+++ b/features/contacts_ui.py
@@ -3,7 +3,7 @@ from tkinter import ttk, messagebox, simpledialog, filedialog, Toplevel, Listbox
 import sqlite3
 from datetime import datetime
 import pandas as pd
-from contact_dialog import AddContactDialog
+from .contact_dialog import AddContactDialog
 from .common import DB_FILE, load_column_widths, save_column_widths, get_settings, get_all_group_names, apply_striped_rows
 
 


### PR DESCRIPTION
## Summary
- fix relative import for `contact_dialog` to avoid ModuleNotFoundError

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 -m compileall -q . && echo 'compile ok'`


------
https://chatgpt.com/codex/tasks/task_e_68406e2adc5883239986beb1d9bb6e0c