### PR TITLE
Add icons and style to buttons

### DIFF
--- a/features/contact_dialog.py
+++ b/features/contact_dialog.py
@@ -63,8 +63,8 @@ class AddContactDialog:
         button_frame = ttk.Frame(self.dialog)
         button_frame.pack(pady=20)
         
-        ttk.Button(button_frame, text="Save", command=self.save).pack(side=tk.LEFT, padx=5)
-        ttk.Button(button_frame, text="Cancel", command=self.cancel).pack(side=tk.LEFT, padx=5)
+        ttk.Button(button_frame, text="💾 Save", command=self.save).pack(side=tk.LEFT, padx=5)
+        ttk.Button(button_frame, text="❌ Cancel", command=self.cancel).pack(side=tk.LEFT, padx=5)
         
         # Wait for the dialog to close
         self.dialog.wait_window()

--- a/features/contacts_ui.py
+++ b/features/contacts_ui.py
@@ -20,17 +20,17 @@ def show_contacts(parent):
     # Button group: Add, Edit, Delete
     btn_group = ttk.Frame(toolbar)
     btn_group.pack(side=tk.LEFT)
-    add_btn = ttk.Button(btn_group, text="Add Contact", command=lambda: add_contact(tree))
+    add_btn = ttk.Button(btn_group, text="➕ Add Contact", command=lambda: add_contact(tree))
     add_btn.pack(side=tk.LEFT, padx=(0, 2))
-    edit_btn = ttk.Button(btn_group, text="Edit Contact", command=lambda: edit_contact(tree))
+    edit_btn = ttk.Button(btn_group, text="✏️ Edit Contact", command=lambda: edit_contact(tree))
     edit_btn.pack(side=tk.LEFT, padx=2)
-    delete_btn = ttk.Button(btn_group, text="Delete Contact(s)", command=lambda: delete_contacts(tree))
+    delete_btn = ttk.Button(btn_group, text="🗑️ Delete Contact(s)", command=lambda: delete_contacts(tree))
     delete_btn.pack(side=tk.LEFT, padx=2)
 
     # Select/Unselect button above the checkbox column
     select_btn_frame = ttk.Frame(toolbar)
     select_btn_frame.pack(side=tk.LEFT, padx=(20, 0))
-    select_btn = ttk.Button(select_btn_frame, text="Select", width=8)
+    select_btn = ttk.Button(select_btn_frame, text="✔️ Select", width=10)
     select_btn.pack()
 
     def toggle_selected_contacts():
@@ -60,7 +60,7 @@ def show_contacts(parent):
     select_btn.config(command=toggle_selected_contacts)
 
     # Import button at the right
-    import_btn = ttk.Button(toolbar, text="Import Contacts from CSV", command=lambda: import_contacts_dialog(tree))
+    import_btn = ttk.Button(toolbar, text="📂 Import Contacts from CSV", command=lambda: import_contacts_dialog(tree))
     import_btn.pack(side=tk.RIGHT, padx=5)
 
     # Group filter dropdown
@@ -322,11 +322,11 @@ def show_groups(parent):
 
     btn_group = ttk.Frame(toolbar)
     btn_group.pack(side=tk.LEFT)
-    add_btn = ttk.Button(btn_group, text="Add Group", command=lambda: add_group(groups_tree))
+    add_btn = ttk.Button(btn_group, text="➕ Add Group", command=lambda: add_group(groups_tree))
     add_btn.pack(side=tk.LEFT, padx=(0, 2))
-    edit_btn = ttk.Button(btn_group, text="Edit Group", command=lambda: edit_group(groups_tree))
+    edit_btn = ttk.Button(btn_group, text="✏️ Edit Group", command=lambda: edit_group(groups_tree))
     edit_btn.pack(side=tk.LEFT, padx=2)
-    delete_btn = ttk.Button(btn_group, text="Delete Group", command=lambda: delete_group(groups_tree))
+    delete_btn = ttk.Button(btn_group, text="🗑️ Delete Group", command=lambda: delete_group(groups_tree))
     delete_btn.pack(side=tk.LEFT, padx=2)
 
     # Groups list

--- a/features/email.py
+++ b/features/email.py
@@ -16,15 +16,15 @@ def show_email_campaigns(parent):
     toolbar.pack(fill=tk.X, pady=(0, 10))
     btn_group = ttk.Frame(toolbar)
     btn_group.pack(side=tk.LEFT)
-    add_btn = ttk.Button(btn_group, text="Add Email Campaign", command=lambda: add_email_campaign(email_tree))
+    add_btn = ttk.Button(btn_group, text="➕ Add Email Campaign", command=lambda: add_email_campaign(email_tree))
     add_btn.pack(side=tk.LEFT, padx=(0, 2))
-    edit_btn = ttk.Button(btn_group, text="Edit Email Campaign", command=lambda: edit_email_campaign(email_tree))
+    edit_btn = ttk.Button(btn_group, text="✏️ Edit Email Campaign", command=lambda: edit_email_campaign(email_tree))
     edit_btn.pack(side=tk.LEFT, padx=2)
-    delete_btn = ttk.Button(btn_group, text="Delete Email Campaign", command=lambda: delete_email_campaign(email_tree))
+    delete_btn = ttk.Button(btn_group, text="🗑️ Delete Email Campaign", command=lambda: delete_email_campaign(email_tree))
     delete_btn.pack(side=tk.LEFT, padx=2)
-    send_btn = ttk.Button(btn_group, text="Send Email Campaign", command=lambda: send_selected_email_campaign(email_tree))
+    send_btn = ttk.Button(btn_group, text="✉️ Send Email Campaign", command=lambda: send_selected_email_campaign(email_tree))
     send_btn.pack(side=tk.LEFT, padx=2)
-    history_btn = ttk.Button(toolbar, text="History", command=lambda: show_email_campaign_history(email_tree))
+    history_btn = ttk.Button(toolbar, text="📜 History", command=lambda: show_email_campaign_history(email_tree))
     history_btn.pack(side=tk.RIGHT, padx=5)
     columns = ("Name", "Subject", "Body")
     email_frame = ttk.Frame(parent)
@@ -281,9 +281,9 @@ def open_email_campaign_wizard(tree, mode="add", campaign=None):
     # Navigation buttons
     nav_frame = ttk.Frame(dialog)
     nav_frame.pack(fill=tk.X, pady=10)
-    prev_btn = ttk.Button(nav_frame, text="<< Previous")
-    next_btn = ttk.Button(nav_frame, text="Next >>")
-    save_btn = ttk.Button(nav_frame, text="Save for Later")
+    prev_btn = ttk.Button(nav_frame, text="⬅️ Previous")
+    next_btn = ttk.Button(nav_frame, text="Next ➡️")
+    save_btn = ttk.Button(nav_frame, text="💾 Save for Later")
     prev_btn.pack(side=tk.LEFT, padx=10)
     next_btn.pack(side=tk.RIGHT, padx=10)
     save_btn.pack(side=tk.RIGHT, padx=10)
@@ -310,7 +310,7 @@ def open_email_campaign_wizard(tree, mode="add", campaign=None):
             timer_var.set("Elapsed: 0s")
             next_btn.config(text="Send Emails")
         else:
-            next_btn.config(text="Next >>")
+            next_btn.config(text="Next ➡️")
     def go_next():
         idx = current_step[0]
         if idx == 0:

--- a/features/main_ui.py
+++ b/features/main_ui.py
@@ -9,6 +9,10 @@ from .history import show_history_dialog
 
 def setup_main_ui(root):
     """Set up the main application UI."""
+    # Global button style for a slightly larger look
+    style = ttk.Style(root)
+    style.configure("TButton", font=("Segoe UI", 11), padding=6)
+
     # Create main container
     main_container = ttk.Frame(root)
     main_container.pack(fill=tk.BOTH, expand=True, padx=20, pady=20)
@@ -23,23 +27,23 @@ def setup_main_ui(root):
 
     # Sidebar buttons
     sidebar_buttons = [
-        ("Contacts", lambda: show_contacts(content)),
-        ("Groups", lambda: show_groups(content)),
-        ("Email Campaigns", lambda: show_email_campaigns(content)),
-        ("SMS Campaign", lambda: show_sms_campaigns(content)),
+        ("👥 Contacts", lambda: show_contacts(content)),
+        ("🗂️ Groups", lambda: show_groups(content)),
+        ("✉️ Email Campaigns", lambda: show_email_campaigns(content)),
+        ("📱 SMS Campaign", lambda: show_sms_campaigns(content)),
     ]
 
     for text, command in sidebar_buttons:
-        btn = ttk.Button(sidebar, text=text, command=command, width=20)
+        btn = ttk.Button(sidebar, text=text, command=command, width=24)
         btn.pack(pady=5)
 
     # Settings button below SMS Campaign
-    settings_btn = ttk.Button(sidebar, text="Settings", command=lambda: open_settings_dialog(root), width=20)
+    settings_btn = ttk.Button(sidebar, text="⚙️ Settings", command=lambda: open_settings_dialog(root), width=24)
     settings_btn.pack(pady=5)
 
     # Move History button to the bottom of the sidebar
     sidebar.pack_propagate(False)
-    history_btn = ttk.Button(sidebar, text="History", command=show_history_dialog, width=20)
+    history_btn = ttk.Button(sidebar, text="📜 History", command=show_history_dialog, width=24)
     history_btn.pack(side=tk.BOTTOM, pady=10)
 
     # Set up the contacts view by default

--- a/features/settings.py
+++ b/features/settings.py
@@ -80,7 +80,7 @@ def open_settings_dialog(parent):
         dialog.destroy()
     btn_frame = ttk.Frame(dialog)
     btn_frame.grid(row=row_idx, column=1, pady=15, sticky=tk.E)
-    ttk.Button(btn_frame, text="Save", command=on_save).pack(side=tk.LEFT, padx=5)
-    ttk.Button(btn_frame, text="Cancel", command=dialog.destroy).pack(side=tk.LEFT, padx=5)
+    ttk.Button(btn_frame, text="💾 Save", command=on_save).pack(side=tk.LEFT, padx=5)
+    ttk.Button(btn_frame, text="❌ Cancel", command=dialog.destroy).pack(side=tk.LEFT, padx=5)
     center_window(dialog, 800, 700)
 

--- a/features/sms.py
+++ b/features/sms.py
@@ -17,11 +17,11 @@ def show_sms_campaigns(parent):
     toolbar.pack(fill=tk.X, pady=(0, 10))
     btn_group = ttk.Frame(toolbar)
     btn_group.pack(side=tk.LEFT)
-    add_btn = ttk.Button(btn_group, text="Add SMS Campaign", command=lambda: add_sms_campaign(sms_tree))
+    add_btn = ttk.Button(btn_group, text="➕ Add SMS Campaign", command=lambda: add_sms_campaign(sms_tree))
     add_btn.pack(side=tk.LEFT, padx=(0, 2))
-    edit_btn = ttk.Button(btn_group, text="Edit SMS Campaign", command=lambda: edit_sms_campaign(sms_tree))
+    edit_btn = ttk.Button(btn_group, text="✏️ Edit SMS Campaign", command=lambda: edit_sms_campaign(sms_tree))
     edit_btn.pack(side=tk.LEFT, padx=2)
-    delete_btn = ttk.Button(btn_group, text="Delete SMS Campaign", command=lambda: delete_sms_campaign(sms_tree))
+    delete_btn = ttk.Button(btn_group, text="🗑️ Delete SMS Campaign", command=lambda: delete_sms_campaign(sms_tree))
     delete_btn.pack(side=tk.LEFT, padx=2)
 
     # SMS Campaigns list
@@ -253,9 +253,9 @@ def open_sms_campaign_wizard(tree, mode="add", campaign=None):
     # Navigation buttons
     nav_frame = ttk.Frame(dialog)
     nav_frame.pack(fill=tk.X, pady=10)
-    prev_btn = ttk.Button(nav_frame, text="<< Previous")
-    next_btn = ttk.Button(nav_frame, text="Next >>")
-    save_btn = ttk.Button(nav_frame, text="Save for Later")
+    prev_btn = ttk.Button(nav_frame, text="⬅️ Previous")
+    next_btn = ttk.Button(nav_frame, text="Next ➡️")
+    save_btn = ttk.Button(nav_frame, text="💾 Save for Later")
     prev_btn.pack(side=tk.LEFT, padx=10)
     next_btn.pack(side=tk.RIGHT, padx=10)
     save_btn.pack(side=tk.RIGHT, padx=10)
@@ -279,7 +279,7 @@ def open_sms_campaign_wizard(tree, mode="add", campaign=None):
             timer_var.set("Elapsed: 0s")
             next_btn.config(text="Send SMS")
         else:
-            next_btn.config(text="Next >>")
+            next_btn.config(text="Next ➡️")
     def go_next():
         idx = current_step[0]
         if idx == 0:


### PR DESCRIPTION
## Summary
- tweak button style globally for slightly larger buttons
- add emoji icons to sidebar navigation
- add emoji icons to contacts, groups, and campaign actions
- update dialog buttons with icons

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684070ed5d288323a288809c30db67e1