### PR TITLE
Update history view and logging

### DIFF
--- a/features/email.py
+++ b/features/email.py
@@ -24,8 +24,6 @@ def show_email_campaigns(parent):
     delete_btn.pack(side=tk.LEFT, padx=2)
     send_btn = ttk.Button(btn_group, text="✉️ Send Email Campaign", command=lambda: send_selected_email_campaign(email_tree))
     send_btn.pack(side=tk.LEFT, padx=2)
-    history_btn = ttk.Button(toolbar, text="📜 History", command=lambda: show_email_campaign_history(email_tree))
-    history_btn.pack(side=tk.RIGHT, padx=5)
     columns = ("Name", "Subject", "Body")
     email_frame = ttk.Frame(parent)
     email_frame.pack(fill=tk.BOTH, expand=True)

--- a/features/history.py
+++ b/features/history.py
@@ -1,25 +1,30 @@
 import tkinter as tk
 from tkinter import ttk
 import sqlite3
-from .common import DB_FILE, apply_striped_rows
+from .common import DB_FILE, apply_striped_rows, center_window
 
 def show_history_dialog():
     hist_win = tk.Toplevel()
-    hist_win.title("Email History")
-    hist_win.geometry("900x500")
+    hist_win.title("History")
+    center_window(hist_win, 900, 500)
     hist_win.transient()
     hist_win.grab_set()
 
+    option_var = tk.StringVar(value="Email")
     search_var = tk.StringVar()
-    search_entry = ttk.Entry(hist_win, textvariable=search_var, width=50)
-    search_entry.pack(padx=10, pady=10, anchor="w")
 
-    columns = ("Timestamp", "Subject", "Body", "Email", "Status")
-    tree = ttk.Treeview(hist_win, columns=columns, show="headings")
-    for col in columns:
-        tree.heading(col, text=col)
-        tree.column(col, width=150)
+    top_frame = ttk.Frame(hist_win)
+    top_frame.pack(fill=tk.X, padx=10, pady=10)
+
+    ttk.Radiobutton(top_frame, text="Email", variable=option_var, value="Email", command=lambda: load_history()).pack(side=tk.LEFT)
+    ttk.Radiobutton(top_frame, text="SMS", variable=option_var, value="SMS", command=lambda: load_history()).pack(side=tk.LEFT, padx=(10,0))
+
+    search_entry = ttk.Entry(top_frame, textvariable=search_var, width=50)
+    search_entry.pack(side=tk.RIGHT)
+
+    tree = ttk.Treeview(hist_win, columns=(), show="headings")
     tree.pack(fill=tk.BOTH, expand=True, padx=10, pady=10)
+
     count_var = tk.StringVar(value="Total: 0 | Selected: 0")
     ttk.Label(hist_win, textvariable=count_var).pack(anchor="w", padx=10, pady=(0,5))
 
@@ -31,18 +36,54 @@ def show_history_dialog():
     tree.bind("<<TreeviewSelect>>", update_counts)
 
     def load_history():
+        for col in tree["columns"]:
+            tree.heading(col, text="")
+        tree.configure(columns=())
         for item in tree.get_children():
             tree.delete(item)
         conn = sqlite3.connect(DB_FILE)
         c = conn.cursor()
-        c.execute("CREATE TABLE IF NOT EXISTS email_history (id INTEGER PRIMARY KEY AUTOINCREMENT, timestamp TEXT, subject TEXT, body TEXT, email TEXT, status TEXT)")
-        query = search_var.get().strip().lower()
-        if query:
-            c.execute("SELECT timestamp, subject, body, email, status FROM email_history")
-            rows = [row for row in c.fetchall() if any(query in str(field).lower() for field in row)]
+        if option_var.get() == "Email":
+            c.execute("""CREATE TABLE IF NOT EXISTS email_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT,
+                subject TEXT,
+                body TEXT,
+                email TEXT,
+                status TEXT
+            )""")
+            columns = ("Timestamp", "Recipient", "Subject", "Body", "Status")
+            tree.configure(columns=columns)
+            for col in columns:
+                tree.heading(col, text=col)
+                tree.column(col, width=150)
+            query = search_var.get().strip().lower()
+            if query:
+                c.execute("SELECT timestamp, email, subject, body, status FROM email_history")
+                rows = [row for row in c.fetchall() if any(query in str(field).lower() for field in row)]
+            else:
+                c.execute("SELECT timestamp, email, subject, body, status FROM email_history ORDER BY id DESC LIMIT 500")
+                rows = c.fetchall()
         else:
-            c.execute("SELECT timestamp, subject, body, email, status FROM email_history ORDER BY id DESC LIMIT 500")
-            rows = c.fetchall()
+            c.execute("""CREATE TABLE IF NOT EXISTS sms_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT,
+                body TEXT,
+                recipient TEXT,
+                status TEXT
+            )""")
+            columns = ("Timestamp", "Recipient", "Body", "Status")
+            tree.configure(columns=columns)
+            for col in columns:
+                tree.heading(col, text=col)
+                tree.column(col, width=150)
+            query = search_var.get().strip().lower()
+            if query:
+                c.execute("SELECT timestamp, recipient, body, status FROM sms_history")
+                rows = [row for row in c.fetchall() if any(query in str(field).lower() for field in row)]
+            else:
+                c.execute("SELECT timestamp, recipient, body, status FROM sms_history ORDER BY id DESC LIMIT 500")
+                rows = c.fetchall()
         for row in rows:
             tree.insert("", tk.END, values=row)
         apply_striped_rows(tree)


### PR DESCRIPTION
## Summary
- remove duplicate History button in email campaign view
- record SMS sending to `sms_history` table
- overhaul history dialog with Email/SMS options and center the window

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684157f4cac48323a5dd1f28a6f55d2e