### PR TITLE
Fix campaign history persistence

### DIFF
--- a/features/email.py
+++ b/features/email.py
@@ -525,6 +525,7 @@ def send_email_campaign(dialog, send_tree, contact_ids, campaign_name, subject, 
                     "INSERT INTO email_campaign_history (campaign_id, contact_id, timestamp, status, error) VALUES (?, ?, datetime('now'), ?, '')",
                     (campaign_id, cid, 'Sent')
                 )
+                conn_th.commit()
                 success += 1
             except Exception as e:
                 send_tree.set(send_tree.get_children()[idx], column="Status", value=f"❌ {e}")
@@ -532,6 +533,7 @@ def send_email_campaign(dialog, send_tree, contact_ids, campaign_name, subject, 
                     "INSERT INTO email_campaign_history (campaign_id, contact_id, timestamp, status, error) VALUES (?, ?, datetime('now'), ?, ?)",
                     (campaign_id, cid, 'Failed', str(e))
                 )
+                conn_th.commit()
                 failed += 1
             counter_var.set(f"Total: {success+failed} | Success: {success} | Failed: {failed}")
             dialog.update_idletasks()


### PR DESCRIPTION
## Summary
- commit email history rows immediately

## Testing
- `python -m py_compile features/email.py`


------
https://chatgpt.com/codex/tasks/task_e_684159b9eef48323b94a16fffb46549e