### PR TITLE
Fix history not displaying

### DIFF
--- a/features/common.py
+++ b/features/common.py
@@ -1,9 +1,18 @@
 import os
+import sys
 import json
 from tkinter import messagebox
-DB_FILE = os.path.join("private", "contacts.db")
-SETTINGS_FILE = os.path.join("private", "settings.json")
-COLUMN_WIDTHS_FILE = os.path.join("private", "column_widths.json")
+
+if getattr(sys, "frozen", False):
+    _BASE_DIR = os.path.dirname(sys.executable)
+else:
+    _BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+PRIVATE_DIR = os.path.join(_BASE_DIR, "private")
+
+DB_FILE = os.path.join(PRIVATE_DIR, "contacts.db")
+SETTINGS_FILE = os.path.join(PRIVATE_DIR, "settings.json")
+COLUMN_WIDTHS_FILE = os.path.join(PRIVATE_DIR, "column_widths.json")
 
 # --- Settings Management ---
 def get_settings():

--- a/services/db.py
+++ b/services/db.py
@@ -1,9 +1,10 @@
 import sqlite3
 import os
 
-DB_FILE = os.path.join("private", "contacts.db")
+from features.common import DB_FILE, PRIVATE_DIR
 
 def init_db():
+    os.makedirs(PRIVATE_DIR, exist_ok=True)
     conn = sqlite3.connect(DB_FILE)
     c = conn.cursor()
     c.execute('''


### PR DESCRIPTION
## Summary
- use application directory for private data files
- ensure contacts.db directory exists before initializing

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68415ba9a8848323995068b4ad301fcb